### PR TITLE
Adding nbf (Not Before) claim handling.

### DIFF
--- a/jwt_verify_lib/jwt.h
+++ b/jwt_verify_lib/jwt.h
@@ -47,6 +47,8 @@ struct Jwt {
   std::vector<std::string> audiences_;
   // sub
   std::string sub_;
+  // not before
+  int64_t nbf_ = 0;
   // expiration
   int64_t exp_ = 0;
 

--- a/jwt_verify_lib/status.h
+++ b/jwt_verify_lib/status.h
@@ -30,6 +30,9 @@ enum class Status {
   // Jwt missing.
   JwtMissed,
 
+  // Jwt not valid yet.
+  JwtNotYetValid,
+
   // Jwt expired.
   JwtExpired,
 

--- a/src/jwt.cc
+++ b/src/jwt.cc
@@ -94,6 +94,15 @@ Status Jwt::parseFromString(const std::string& jwt) {
       return Status::JwtPayloadParseError;
     }
   }
+  if (payload_json.HasMember("nbf")) {
+    if (payload_json["nbf"].IsInt()) {
+      nbf_ = payload_json["nbf"].GetInt();
+    } else {
+      return Status::JwtPayloadParseError;
+    }
+  } else {
+    nbf_ = 0;
+  }
   if (payload_json.HasMember("exp")) {
     if (payload_json["exp"].IsInt()) {
       exp_ = payload_json["exp"].GetInt();

--- a/src/jwt_test.cc
+++ b/src/jwt_test.cc
@@ -23,11 +23,11 @@ TEST(JwtParseTest, GoodJwt) {
   // JWT with
   // Header:  {"alg":"RS256","typ":"JWT"}
   // Payload:
-  // {"iss":"https://example.com","sub":"test@example.com","exp":1501281058}
+  // {"iss":"https://example.com","sub":"test@example.com","exp":1501281058,"nbf":1501281000}
   const std::string jwt_text =
       "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9."
-      "eyJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tIiwic3ViIjoidGVzdEBleGFtcGxlLmNvbSIs"
-      "ImV4cCI6MTUwMTI4MTA1OH0.U2lnbmF0dXJl";
+      "eyJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tIiwic3ViIjoidGVzdEBleGFtcGxlLmNvbSIsImV4"
+      "cCI6MTUwMTI4MTA1OCwibmJmIjoxNTAxMjgxMDAwfQo.U2lnbmF0dXJl";
 
   Jwt jwt;
   ASSERT_EQ(jwt.parseFromString(jwt_text), Status::Ok);
@@ -37,6 +37,7 @@ TEST(JwtParseTest, GoodJwt) {
   EXPECT_EQ(jwt.iss_, "https://example.com");
   EXPECT_EQ(jwt.sub_, "test@example.com");
   EXPECT_EQ(jwt.audiences_, std::vector<std::string>());
+  EXPECT_EQ(jwt.nbf_, 1501281000);
   EXPECT_EQ(jwt.exp_, 1501281058);
   EXPECT_EQ(jwt.signature_, "Signature");
 }
@@ -57,6 +58,7 @@ TEST(JwtParseTest, GoodJwtWithMultiAud) {
   EXPECT_EQ(jwt.iss_, "https://example.com");
   EXPECT_EQ(jwt.sub_, "https://example.com");
   EXPECT_EQ(jwt.audiences_, std::vector<std::string>({"aud1", "aud2"}));
+  EXPECT_EQ(jwt.nbf_, 0); // When there's no nbf claim default to 0
   EXPECT_EQ(jwt.exp_, 1517878659);
   EXPECT_EQ(jwt.signature_, "Signature");
 }

--- a/src/status.cc
+++ b/src/status.cc
@@ -26,6 +26,8 @@ std::string getStatusString(Status status) {
 
     case Status::JwtMissed:
       return "Jwt is missing";
+    case Status::JwtNotYetValid:
+      return "Jwt not yet valid";
     case Status::JwtExpired:
       return "Jwt is expired";
     case Status::JwtBadFormat:


### PR DESCRIPTION
Added handling of the Not Before claim which must be validated to ensure
that an application does accept JWTs before their validity period.

Add new test asserts that verify the nbf_ field is set correctly when present
else it is defaulted to 0.