### PR TITLE
bazel: Allow to distdir all dependencies

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -1,8 +1,14 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+BORINGSSL_COMMIT = "9df0c47bc034d60d73d216cd0e090707b3fbea58"  # same as Envoy
+BORINGSSL_SHA256 = "86d0614bb9e6cb4e6444b83bb1f031755eff4bbe52cd8f4cd5720bb84a7ea9f5"
+
 def boringssl_repositories(bind=True):
-    native.git_repository(
+    http_archive(
         name = "boringssl",
-        commit = "9df0c47bc034d60d73d216cd0e090707b3fbea58",  # same as Envoy
-        remote = "https://boringssl.googlesource.com/boringssl",
+        strip_prefix = "boringssl-" + BORINGSSL_COMMIT,
+        url = "https://github.com/google/boringssl/archive/" + BORINGSSL_COMMIT + ".tar.gz",
+        sha256 = BORINGSSL_SHA256,
     )
 
     if bind:
@@ -11,12 +17,16 @@ def boringssl_repositories(bind=True):
             actual = "@boringssl//:ssl",
         )
 
+GOOGLETEST_COMMIT = "43863938377a9ea1399c0596269e0890b5c5515a"
+GOOGLETEST_SHA256 = "7c8ece456ad588c30160429498e108e2df6f42a30888b3ec0abf5d9792d9d3a0"
+
 def googletest_repositories(bind=True):
-    native.new_git_repository(
+    http_archive(
         name = "googletest_git",
-        build_file = "googletest.BUILD",
-        commit = "43863938377a9ea1399c0596269e0890b5c5515a",
-        remote = "https://github.com/google/googletest.git",
+        build_file = "//:googletest.BUILD",
+        strip_prefix = "googletest-" + GOOGLETEST_COMMIT,
+        url = "https://github.com/google/googletest/archive/" + GOOGLETEST_COMMIT + ".tar.gz",
+        sha256 = GOOGLETEST_SHA256,
     )
 
     if bind:
@@ -35,12 +45,16 @@ def googletest_repositories(bind=True):
             actual = "@googletest_git//:googletest_prod",
         )
 
+RAPIDJSON_COMMIT = "f54b0e47a08782a6131cc3d60f94d038fa6e0a51"
+RAPIDJSON_SHA256 = "4a76453d36770c9628d7d175a2e9baccbfbd2169ced44f0cb72e86c5f5f2f7cd"
+
 def rapidjson_repositories(bind=True):
-    native.new_git_repository(
+    http_archive(
         name = "com_github_tencent_rapidjson",
-        build_file = "rapidjson.BUILD",
-        commit = "f54b0e47a08782a6131cc3d60f94d038fa6e0a51",
-        remote = "https://github.com/tencent/rapidjson.git",
+        build_file = "//:rapidjson.BUILD",
+        strip_prefix = "rapidjson-" + RAPIDJSON_COMMIT,
+        url = "https://github.com/tencent/rapidjson/archive/" + RAPIDJSON_COMMIT + ".tar.gz",
+        sha256 = RAPIDJSON_SHA256,
     )
 
     if bind:
@@ -49,11 +63,15 @@ def rapidjson_repositories(bind=True):
             actual = "@com_github_tencent_rapidjson//:rapidjson",
         )
 
+ABSEIL_COMMIT = "cc8dcd307b76a575d2e3e0958a4fe4c7193c2f68"  # same as Envoy
+ABSEIL_SHA256 = "e35082e88b9da04f4d68094c05ba112502a5063712f3021adfa465306d238c76"
+
 def abseil_repositories(bind=True):
-    native.git_repository(
+    http_archive(
         name = "com_google_absl",
-        commit = "787891a3882795cee0364e8a0f0dda315578d155",
-        remote = "https://github.com/abseil/abseil-cpp",
+        strip_prefix = "abseil-cpp-" + ABSEIL_COMMIT,
+        url = "https://github.com/abseil/abseil-cpp/archive/" + ABSEIL_COMMIT + ".tar.gz",
+        sha256 = ABSEIL_SHA256,
     )
 
     if bind:
@@ -67,9 +85,12 @@ def abseil_repositories(bind=True):
         )
     _cctz_repositories(bind)
 
+CCTZ_COMMIT = "e19879df3a14791b7d483c359c4acd6b2a1cd96b"
+CCTZ_SHA256 = "35d2c6cf7ddef1cf7c1bb054bdf2e8d7778242f6d199591a834c14d224b80c39"
+
 def _cctz_repositories(bind=True):
-    native.git_repository(
+    http_archive(
         name = "com_googlesource_code_cctz",
-        commit = "e19879df3a14791b7d483c359c4acd6b2a1cd96b",
-        remote = "https://github.com/google/cctz",
+        url = "https://github.com/google/cctz/archive/" + CCTZ_COMMIT + ".tar.gz",
+        sha256 = CCTZ_SHA256,
     )


### PR DESCRIPTION
To use --distdir option of Bazel (which allows to use previously
fetched tarballs instead of downloading dependencies during
build), all dependencies should use http instead of git and need
to have sha256 sums specified.

This change also updates Abseil and BoringSSL to versions used by
Envoy.