### PR TITLE
Add HS384 and HS512 support

### DIFF
--- a/src/jwks.cc
+++ b/src/jwks.cc
@@ -198,7 +198,8 @@ Status extractJwkFromJwkEC(const ::google::protobuf::Struct& jwk_pb,
 
 Status extractJwkFromJwkOct(const ::google::protobuf::Struct& jwk_pb,
                             Jwks::Pubkey* jwk) {
-  if (jwk->alg_specified_ && jwk->alg_ != "HS256") {
+  if (jwk->alg_specified_ && jwk->alg_ != "HS256" &&
+      jwk->alg_ != "HS384" && jwk->alg_ != "HS512") {
     return Status::JwksHMACKeyBadAlg;
   }
 

--- a/src/jwt.cc
+++ b/src/jwt.cc
@@ -62,7 +62,8 @@ Status Jwt::parseFromString(const std::string& jwt) {
   }
 
   if (alg_ != "RS256" && alg_ != "ES256" && alg_ != "RS384" &&
-      alg_ != "RS512" && alg_ != "HS256") {
+      alg_ != "RS512" && alg_ != "HS256" && alg_ != "HS384" &&
+      alg_ != "HS512") {
     return Status::JwtHeaderNotImplementedAlg;
   }
 

--- a/src/status.cc
+++ b/src/status.cc
@@ -105,7 +105,7 @@ std::string getStatusString(Status status) {
       return "[y] field is not string for an EC key";
 
     case Status::JwksHMACKeyBadAlg:
-      return "[alg] is not [HS256] for an HMAC key";
+      return "[alg] does not start with [HS] for an HMAC key";
     case Status::JwksHMACKeyMissingK:
       return "[k] field is missing for an HMAC key";
     case Status::JwksHMACKeyBadK:

--- a/src/verify.cc
+++ b/src/verify.cc
@@ -190,11 +190,22 @@ Status verifyJwt(const Jwt& jwt, const Jwks& jwks, uint64_t now) {
         // Verification succeeded.
         return Status::Ok;
       }
-    } else if (jwk->kty_ == "oct" &&
-      verifySignatureOct(jwk->hmac_key_, EVP_sha256(), jwt.signature_,
-                         signed_data)) {
-      // Verification succeeded.
-      return Status::Ok;
+    } else if (jwk->kty_ == "oct") {
+      const EVP_MD* md;
+      if (jwt.alg_ == "HS384") {
+        md = EVP_sha384();
+      } else if (jwt.alg_ == "HS512") {
+        md = EVP_sha512();
+      } else {
+        // default to SHA256
+        md = EVP_sha256();
+      }
+
+      if (verifySignatureOct(jwk->hmac_key_, md, jwt.signature_,
+                           signed_data)) {
+        // Verification succeeded.
+        return Status::Ok;
+      }
     }
   }
 

--- a/src/verify_jwk_hmac_test.cc
+++ b/src/verify_jwk_hmac_test.cc
@@ -37,6 +37,20 @@ const std::string SymmetricKeyHMAC = R"(
       "kid": "b3319a147514df7ee5e4bcdee51350cc890cc89e",
       "k": "nyeGXUHngW64dyg2EuDs_8x6VGa14Bkrv1SFQwOzKfI"
     },
+    {
+      "kty": "oct",
+      "alg": "HS384",
+      "use": "sig",
+      "kid": "cda01077a6aa4b0088a6e959044977ef9e51c28b",
+      "k": "5xYkMHiMVnCBbFEt0Uh1LhIbFB6yakzp2Mh7ESBMUCDq4zMO6WgCMaQwP332FH47"
+    },
+    {
+      "kty": "oct",
+      "alg": "HS512",
+      "use": "sig",
+      "kid": "f6a7bd9ffd784388924f126280a746964ba61268",
+      "k": "ID3awf7bo607gitUDWylMMhUyVFr4ZAmnysPw4675A1YmOaYajbqLmMA7fohGLYZdZyaluaiugKvnnGLYTDoUA"
+    },
 
   ]
 }
@@ -68,12 +82,37 @@ const std::string JwtTextNoKidLongExp =
 // {"alg":"HS256","typ":"JWT","kid":"b3319a147514df7ee5e4bcdee51350cc890cc89e"}
 // Payload:
 // {"iss":"https://example.com","sub":"test@example.com","exp":1501281058}
-const std::string JwtTextWithCorrectKid =
+const std::string JwtHS256TextWithCorrectKid =
     "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImIzMzE5YTE0NzUxNGRmN2VlNWU0"
     "YmNkZWU1MTM1MGNjODkwY2M4OWUifQ."
     "eyJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tIiwic3ViIjoidGVzdEBleGFtcGxlLmNvbSIs"
     "ImV4cCI6MTUwMTI4MTA1OH0."
     "QqSMCAY5UDBvySx0VQhGqIvomZaSRUJOCT6ktV3BhL8";
+
+// JWT with correct kid
+// Header:
+// {"alg":"HS384","typ":"JWT","kid":"cda01077a6aa4b0088a6e959044977ef9e51c28b"}
+// Payload:
+// {"iss":"https://example.com","sub":"test@example.com","exp":1501281058}
+const std::string JwtHS384TextWithCorrectKid =
+  "eyJhbGciOiJIUzM4NCIsInR5cCI6IkpXVCIsImtpZCI6ImNkYTAxMDc3YTZhYTRiMDA4OGE2"
+  "ZTk1OTA0NDk3N2VmOWU1MWMyOGIifQ."
+  "eyJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tIiwic3ViIjoidGVzdEBleGFtcGxlLmNvbSIs"
+  "ImV4cCI6MTUwMTI4MTA1OH0."
+  "F69ivpIRbgrmy1j6_MHl10xDW8iPdzsHAIgln3Z9PEemH9heiQoDUOgG91kA44fL";
+
+// JWT with correct kid
+// Header:
+// {"alg":"HS512","typ":"JWT","kid":"f6a7bd9ffd784388924f126280a746964ba61268"}
+// Payload:
+// {"iss":"https://example.com","sub":"test@example.com","exp":1501281058}
+const std::string JwtHS512TextWithCorrectKid =
+  "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCIsImtpZCI6ImY2YTdiZDlmZmQ3ODQzODg5MjRm"
+  "MTI2MjgwYTc0Njk2NGJhNjEyNjgifQ."
+  "eyJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tIiwic3ViIjoidGVzdEBleGFtcGxlLmNvbSIs"
+  "ImV4cCI6MTUwMTI4MTA1OH0."
+  "YdILUM4zaeIRuxEMLV13qMX3d1sp63juPXwbpOp_HUjNdGGvocthipOxjQur6JtCLmIfvrI4"
+  "XNrkxVWd-qS_3g";
 
 // JWT with existing but incorrect kid
 // Header:
@@ -127,9 +166,31 @@ TEST_F(VerifyJwkHmacTest, NoKidLongExpOK) {
   });
 }
 
-TEST_F(VerifyJwkHmacTest, CorrectKidOK) {
+TEST_F(VerifyJwkHmacTest, CorrectKidHS256OK) {
   Jwt jwt;
-  EXPECT_EQ(jwt.parseFromString(JwtTextWithCorrectKid), Status::Ok);
+  EXPECT_EQ(jwt.parseFromString(JwtHS256TextWithCorrectKid), Status::Ok);
+  EXPECT_EQ(verifyJwt(jwt, *jwks_, 1), Status::Ok);
+
+
+  fuzzJwtSignature(jwt, [this](const Jwt& jwt) {
+    EXPECT_EQ(verifyJwt(jwt, *jwks_, 1), Status::JwtVerificationFail);
+  });
+}
+
+TEST_F(VerifyJwkHmacTest, CorrectKidHS384OK) {
+  Jwt jwt;
+  EXPECT_EQ(jwt.parseFromString(JwtHS384TextWithCorrectKid), Status::Ok);
+  EXPECT_EQ(verifyJwt(jwt, *jwks_, 1), Status::Ok);
+
+
+  fuzzJwtSignature(jwt, [this](const Jwt& jwt) {
+    EXPECT_EQ(verifyJwt(jwt, *jwks_, 1), Status::JwtVerificationFail);
+  });
+}
+
+TEST_F(VerifyJwkHmacTest, CorrectKidHS512OK) {
+  Jwt jwt;
+  EXPECT_EQ(jwt.parseFromString(JwtHS512TextWithCorrectKid), Status::Ok);
   EXPECT_EQ(verifyJwt(jwt, *jwks_, 1), Status::Ok);
 
 


### PR DESCRIPTION
Add support for HS384 and HS512

Example envoy config that uses the HS384 key `secret` (to anyone reading this, your key should be at least 48 bytes (384/8=48), not 6):

```
http_filters:
- name: envoy.filters.http.jwt_authn
  config:
    providers:
      sample_jwt_provider:
        issuer: sample.com
        local_jwks:
          inline_string: "{\"keys\": [{\"kty\":\"oct\",\"k\":\"c2VjcmV0\",\"alg\":\"HS384\"}]}"
        forward: true
        forward_payload_header: "plain-authorization"
    rules:
    - match:
        prefix: /protect
      requires:
        provider_name: sample_jwt_provider
```

Example envoy config that uses the HS512 key `secret` (to anyone reading this, your key should be at least 64 bytes (512/8=64), not 6):

```
http_filters:
- name: envoy.filters.http.jwt_authn
  config:
    providers:
      sample_jwt_provider:
        issuer: sample.com
        local_jwks:
          inline_string: "{\"keys\": [{\"kty\":\"oct\",\"k\":\"c2VjcmV0\",\"alg\":\"HS512\"}]}"
        forward: true
        forward_payload_header: "plain-authorization"
    rules:
    - match:
        prefix: /protect
      requires:
        provider_name: sample_jwt_provider
```