### PR TITLE
Add support for parsing PKCS8 formatted PEM keys

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -65,8 +65,8 @@ cc_test(
 cc_test(
     name = "jwks_test",
     srcs = [
-        "src/test_common.h",
         "src/jwks_test.cc",
+        "src/test_common.h",
     ],
     linkopts = [
         "-lm",
@@ -186,6 +186,23 @@ cc_test(
     srcs = [
         "src/test_common.h",
         "src/verify_jwk_hmac_test.cc",
+    ],
+    linkopts = [
+        "-lm",
+        "-lpthread",
+    ],
+    linkstatic = 1,
+    deps = [
+        ":jwt_verify_lib",
+        "//external:googletest_main",
+    ],
+)
+
+cc_test(
+    name = "verify_pkcs_test",
+    srcs = [
+        "src/test_common.h",
+        "src/verify_pkcs_test.cc",
     ],
     linkopts = [
         "-lm",

--- a/jwt_verify_lib/jwks.h
+++ b/jwt_verify_lib/jwks.h
@@ -36,7 +36,7 @@ namespace jwt_verify {
 class Jwks : public WithStatus {
  public:
   // Format of public key.
-  enum Type { PEM, JWKS };
+  enum Type { PEM, JWKS, PKCS8 };
 
   // Create from string
   static std::unique_ptr<Jwks> createFrom(const std::string& pkey, Type type);
@@ -66,6 +66,8 @@ class Jwks : public WithStatus {
   void createFromPemCore(const std::string& pkey_pem);
   // Create Jwks
   void createFromJwksCore(const std::string& pkey_jwks);
+  // Create PKCS8
+  void createFromPkcs8Core(const std::string& pkey_pem);
 
   // List of Jwks
   std::vector<PubkeyPtr> keys_;

--- a/jwt_verify_lib/status.h
+++ b/jwt_verify_lib/status.h
@@ -155,6 +155,14 @@ enum class Status {
   JwksX509ParseError,
   // X509 get pubkey fails
   JwksX509GetPubkeyError,
+
+  // Key type is not supported.
+  Pkcs8NotImplementedKty,
+  // Unable to parse public key
+  Pkcs8PemParseError,
+
+  // Failed to create BIO
+  BioAllocError,
 };
 
 /**

--- a/src/jwks_test.cc
+++ b/src/jwks_test.cc
@@ -730,6 +730,88 @@ TEST(JwksParseTest, JwksX509WrongPubkey) {
   EXPECT_EQ(jwks->getStatus(), Status::JwksX509ParseError);
 }
 
+TEST(JwksParseTest, goodPKCS8RSA) {
+  const std::string pem_text = R"(
+-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzUPYX/CJFCPg5fDfnTsV
+6J0Lq2zMqCIj0/2taAsQm7sqrc5SCIeiDXypNzYYqshScbHPEfyj4egEqMMf9its
+WY4khLWHcAd23ICHPdbga0YP4z+VTOkIMEpmJ8Oat68oeBaYhTMW1jr+9A2N/U/w
+1AnketucyFFk0bkkmGuOefytbuBoxA2mkM+ZBVFRCXeiWq4LjgHZNpMNZ9Dz30Jk
+6E+A0y2cMje4x6zMfulDf1ED6FN2LHqNE6uScFo5YL3tnvqMhkjJFMIzdvK4MWWh
+2uTclOhgCH5rA6wQO2vWH8RRewaEfF0ihtg1WafSrcWK2MPDFI9/XhwzkBPBCG9l
+ZQIDAQAB
+-----END PUBLIC KEY-----
+)";
+  auto jwks = Jwks::createFrom(pem_text, Jwks::PKCS8);
+  EXPECT_EQ(jwks->getStatus(), Status::Ok);
+  EXPECT_EQ(jwks->keys().size(), 1);
+  EXPECT_TRUE(jwks->keys()[0]->pem_format_);
+}
+
+TEST(JwksParseTest, Pkcs8WrongHeader) {
+  const std::string pem_text = R"(
+-----BEGIN CERTIFICATE KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzUPYX/CJFCPg5fDfnTsV
+6J0Lq2zMqCIj0/2taAsQm7sqrc5SCIeiDXypNzYYqshScbHPEfyj4egEqMMf9its
+WY4khLWHcAd23ICHPdbga0YP4z+VTOkIMEpmJ8Oat68oeBaYhTMW1jr+9A2N/U/w
+1AnketucyFFk0bkkmGuOefytbuBoxA2mkM+ZBVFRCXeiWq4LjgHZNpMNZ9Dz30Jk
+6E+A0y2cMje4x6zMfulDf1ED6FN2LHqNE6uScFo5YL3tnvqMhkjJFMIzdvK4MWWh
+2uTclOhgCH5rA6wQO2vWH8RRewaEfF0ihtg1WafSrcWK2MPDFI9/XhwzkBPBCG9l
+ZQIDAQAB
+-----END CERTIFICATE KEY-----
+)";
+  auto jwks = Jwks::createFrom(pem_text, Jwks::PKCS8);
+  EXPECT_EQ(jwks->getStatus(), Status::Pkcs8PemParseError);
+}
+
+TEST(JwksParseTest, Pkcs8InvalidKey) {
+  const std::string pem_text = R"(
+-----BEGIN PUBLIC KEY-----
+bad-pub-key
+-----END PUBLIC KEY-----
+)";
+  auto jwks = Jwks::createFrom(pem_text, Jwks::PKCS8);
+  EXPECT_EQ(jwks->getStatus(), Status::Pkcs8PemParseError);
+}
+
+TEST(JwksParseTest, Pkcs8EcUnimplimented) {
+  const std::string pem_text = R"(
+-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEYaOv1HVESfIWB6jnkijUTPKvwkFu
+CQnMe3gk4tp4DhYBSzTl6UXz9iRj15FMlmQpl9fV5nBfZMoUm47EkO7uaQ==
+-----END PUBLIC KEY-----
+)";
+  auto jwks = Jwks::createFrom(pem_text, Jwks::PKCS8);
+  EXPECT_EQ(jwks->getStatus(), Status::Pkcs8NotImplementedKty);
+}
+
+TEST(JwksParseTest, Pkcs8DsaUnimplimented) {
+  const std::string pem_text = R"(
+-----BEGIN PUBLIC KEY-----
+MIIDRjCCAjkGByqGSM44BAEwggIsAoIBAQDWMfB0ccDLpds14iKIKMu/O0WgIjHu
+yvUvDtnzdwiMDxOlbs5SkB2dFDUPRO+WNCuSJgYGsIgVBnHUEwTRm8jqXrjUoVRN
+Vj5eQO9/UXit/Kadt1lCHlUeVqeA8KAApN/gbr1y0hrkMyHNDpjznR3/z8uc0Za9
+iRkB4R0YDyGnrGI58WKuiOsSJpc7XOHHKhHFoXYy/g/De5pfV9d5s4FYjJNi2Ew8
+SdWy2gztUnf3BrIbwWSUXNtm2W+zql9qTCFwXMEArKYwlk/6au0tMCW2/rfUAfYU
+9Y9Vgi5rgEW3I/YV7mgYzw5sWFgj8wxEbUcvNM7iqgh/w054ZesTz58jAiEA7FKX
+3tTqBtTTiUYVHXjaPUBiAAQevbFEMr4dVo0os2ECggEAEdhxaTqMQ2Wb625cDaWI
+2OLpOXot2RTMSGQNKGi05OgsAKw6yVjwJuqqEdZi6XCtZ/SNUEZA8zmUyhdjj7ht
+SeM+Km3b2M+FjLm7Wtvgl2QjiLmKhZKTrlZETs18aTkS8OrU5S6w2LDzOtZ6T7Ap
+/A9tPf1F4CHnfykYmYDWcenZPhZHD/pv1ovSi5u7GNtvp1R2EsMV0+Pp0PwmSyX2
+RAGjkSGyEtDjaXHy2Wh7b5BsfO2ixJb+6m8eBGaLxCZ3Su16R9C1xQ/lFHj6HPTV
+3QvjayxaVVf3BjJgDaZX7b9gWuWhkP4eJ8M/xlfE2lJprl2RaDeZvpa22lP5Lcor
+GgOCAQUAAoIBADk+JlpQuV2D0yMnS5ewzkiU5KjcwSWgTrw4KLWRFFfYWtdHy/Ot
+xaafLzA04QM6Jh4q+iOJVhk2toxjW2+/6lYbmest83VPKGAaPs49gmWOVvU2gExp
+MobhZpB4uwTUwanooCYOt5pV2Ysw8iOYI7H84L02yJJDFcv9qJJaw6+ZzZoSVE5q
+17w7KTdUcvO46dDddIAknS1th2YrzFOj6syy56Y0nozMBgT6IQbbKD3WEWGc29Qw
++2/C+wusfP/gWpG6yCPpKXDLIWv583H+CoXD54dyJ3xH+c1UeDm+/pAM/oBynFFj
+9y24N/KIm3v5f4Fb1v3v/by0kcfcg6vkRiQ=
+-----END PUBLIC KEY-----
+)";
+  auto jwks = Jwks::createFrom(pem_text, Jwks::PKCS8);
+  EXPECT_EQ(jwks->getStatus(), Status::Pkcs8NotImplementedKty);
+}
+
 }  // namespace
 }  // namespace jwt_verify
 }  // namespace google

--- a/src/status.cc
+++ b/src/status.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <map>
-
 #include "jwt_verify_lib/status.h"
+
+#include <map>
 
 namespace google {
 namespace jwt_verify {
@@ -125,6 +125,14 @@ std::string getStatusString(Status status) {
       return "X509 parse pubkey fails";
     case Status::JwksX509GetPubkeyError:
       return "X509 parse pubkey internal fails: get pubkey";
+
+    case Status::Pkcs8NotImplementedKty:
+      return "PKCS8 Key type is not supported";
+    case Status::Pkcs8PemParseError:
+      return "PKCS8 pubkey parse fails";
+
+    case Status::BioAllocError:
+      return "Failed to create BIO due to memory allocation failure";
   };
   return "";
 }

--- a/src/verify_pkcs_test.cc
+++ b/src/verify_pkcs_test.cc
@@ -1,0 +1,114 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gtest/gtest.h"
+#include "jwt_verify_lib/verify.h"
+#include "src/test_common.h"
+
+namespace google {
+namespace jwt_verify {
+namespace {
+
+// To generate new keys:
+// openssl req -x509 -nodes -newkey rsa:2048 -keyout rsa_private.pem -subj "/CN=unused"
+// openssl rsa -in rsa_private.pem -pubout -out rsa_public.pem
+// To generate new JWTs: Use jwt.io with the generated private key. 
+
+const std::string pubkey = R"(
+-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzgP9Xw2xvul2pZNjCpJD
+/L16FmKH/zt53seeo2/eBKzcUs3nDO33aYdjsCAAFaQfXSAe0PfmwbytmH9RMHOJ
+PUU2ApcEt63K5+3v5n+kqKfmym2lOebqpLgsdXIXvTsHYYy/10GGM+NPgyMUgU8q
+JSaPOOA/ZJ1eWQTyfgJCPeIarzcTaf+eSD3CQaDDpi488RFc3O86pho5x3KTHSg4
+CxHp0ua1RV2pNGJP1BqN0oX09Rgpjo7GE+ukpCMO7zOCwSeBjnqL/zdJ7pjo//u0
+dhGpdbcejNZhl1NN+0q1eogwJPM295/7xRSW77mmcUI8W4oLDHLz1zxRoX9yK9xv
+3wIDAQAB
+-----END PUBLIC KEY-----
+)";
+
+// JWT with
+// Header:  { "alg": "RS256", "typ": "JWT" }
+// Payload: {"iss":"https://example.com","sub":"test@example.com" }
+const std::string JwtPkcs8Rs256 =
+    "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9."
+    "eyJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tIiwic3ViIjoidGVzdEBleGFtcGxlLmNvbSJ9."
+    "FFSVKKWsuhwHaZDW-nsKcVY0_hEAHvfk7PNa-zRES9IPrhZU-dtZghhhP4xDdDc-"
+    "w9Phg6Zy70JFOYBc7nvsaz4uRQg6YDYv5PEJaUcUnL4tu1_IK5KzuGnxLHJMVt-7F6EK_"
+    "HVbvTgmTp6mruC1gvKr3aY3t9u_FQ6mSaziNecIlh9MzZlJ7MVQQhb9A047lbUtxGueGk0l3f-"
+    "Idcg9idyIiBTqQuOfT1La088e4aCLQo6rCdAUsyeKaIjZyZmh-xK0-"
+    "YMdobCyMBdEbeN5KWKv9kdSac0HaWbDNn_WKgtkmyIIv5iyPbCuo4vaZWwEQ7NSNsnQDe_"
+    "BciDrX3npcg";
+
+// JWT with
+// Header:  { "alg": "RS384", "typ": "JWT" }
+// Payload: {"iss":"https://example.com", "sub":"test@example.com" }
+const std::string JwtPkcs8Rs384 =
+    "eyJhbGciOiJSUzM4NCIsInR5cCI6IkpXVCJ9."
+    "eyJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tIiwic3ViIjoidGVzdEBleGFtcGxlLmNvbSJ9."
+    "ec8gDlwNnT189m78UklZ239UcThdRUrlh3DICZcunjb0h6nRrn8xX1zhF9OWiDjIS6Cu7c6kzA"
+    "OgWu2ZDNf7WSG0JjmcpLVw8W-Zxs0zs6ycxQETz5d_hxmV0kGNRF0nM1EC5DfhB_"
+    "ByOVwRkaHcM-kpX6t_zvZoX_FGJTp51QzUeGHL1I3WxSVrsTBpBGY_qLGU0dEE9rXgLEEw5o_"
+    "k05f92PTPBTwq7J3kUYzwxEI9dFb10q9wQYMn1lRL2-"
+    "Tw0LpdYYKcE8TWVaoNHSAsQQqErMwggIrxW4bg7V66EUSzzFUO8etFs2NN0mWobBQYG7kaCLVS"
+    "eHlbAyIQagmjMg";
+
+// JWT with
+// Header:  { "alg": "RS512", "typ": "JWT" }
+// Payload: {"iss":"https://example.com", "sub":"test@example.com" }
+const std::string JwtPkcs8Rs512 =
+    "eyJhbGciOiJSUzUxMiIsInR5cCI6IkpXVCJ9."
+    "eyJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tIiwic3ViIjoidGVzdEBleGFtcGxlLmNvbSJ9."
+    "daL48TAqnpXWRltqVZSSVXwRxTuaI1hL5FqdUKNuUUHgDP511EOb_"
+    "DmsgajvwYs4EmrS2kDguhur0vDIV4RbW3EHMPz3ngMNbP56oMyXOaiXc4dbEGhJraxZ3Y7xh2f"
+    "H_CNOiXkEuAJns6fCxKHk-"
+    "Wl1fV36k4mmPFpuxiZqiuRCP6c6Vprt55HKmO3cipjR0wBGrQi07vBwe2uHcZ6R4I6klCgVchq"
+    "Ms5qq2T1jSnLir6Z4YDgbw6L7lO_x9w2Rhw6R0impjDya2sBrQ-KdATaE5Zkyd5BU6L-"
+    "IEqKrrJdVTr_rhBYMIMDjDk7ufioIY-6A0zBDQdM2xw3evwBE_w";
+
+TEST(VerifyPKCSTestRs256, OKPem) {
+  Jwt jwt;
+  EXPECT_EQ(jwt.parseFromString(JwtPkcs8Rs256), Status::Ok);
+  auto jwks = Jwks::createFrom(pubkey, Jwks::Type::PKCS8);
+  EXPECT_EQ(jwks->getStatus(), Status::Ok);
+  EXPECT_EQ(verifyJwt(jwt, *jwks, 1), Status::Ok);
+  fuzzJwtSignature(jwt, [&jwks](const Jwt& jwt) {
+    EXPECT_EQ(verifyJwt(jwt, *jwks, 1), Status::JwtVerificationFail);
+  });
+}
+
+TEST(VerifyPKCSTestRs384, OKPem) {
+  Jwt jwt;
+  EXPECT_EQ(jwt.parseFromString(JwtPkcs8Rs384), Status::Ok);
+  auto jwks = Jwks::createFrom(pubkey, Jwks::Type::PKCS8);
+  EXPECT_EQ(jwks->getStatus(), Status::Ok);
+  EXPECT_EQ(verifyJwt(jwt, *jwks, 1), Status::Ok);
+  fuzzJwtSignature(jwt, [&jwks](const Jwt& jwt) {
+    EXPECT_EQ(verifyJwt(jwt, *jwks, 1), Status::JwtVerificationFail);
+  });
+}
+
+TEST(VerifyPKCSTestRs512, OKPem) {
+  Jwt jwt;
+  EXPECT_EQ(jwt.parseFromString(JwtPkcs8Rs512), Status::Ok);
+  auto jwks = Jwks::createFrom(pubkey, Jwks::Type::PKCS8);
+  EXPECT_EQ(jwks->getStatus(), Status::Ok);
+  EXPECT_EQ(verifyJwt(jwt, *jwks, 1), Status::Ok);
+  fuzzJwtSignature(jwt, [&jwks](const Jwt& jwt) {
+    EXPECT_EQ(verifyJwt(jwt, *jwks, 1), Status::JwtVerificationFail);
+  });
+}
+
+}  // namespace
+}  // namespace jwt_verify
+}  // namespace google


### PR DESCRIPTION
This adds support for parsing PKCS8 formatted RSA keys. Support for PKCS8 formatted EC keys will be added in the next Pull request.