### PR TITLE
Remove alg_specified_ and kid_specified_ flags.

### DIFF
--- a/jwt_verify_lib/jwks.h
+++ b/jwt_verify_lib/jwks.h
@@ -48,8 +48,6 @@ class Jwks : public WithStatus {
     std::string kty_;
     std::string alg_;
     std::string crv_;
-    bool alg_specified_ = false;
-    bool kid_specified_ = false;
     bssl::UniquePtr<RSA> rsa_;
     bssl::UniquePtr<EC_KEY> ec_key_;
     bssl::UniquePtr<BIO> bio_;

--- a/src/jwks_test.cc
+++ b/src/jwks_test.cc
@@ -51,13 +51,9 @@ TEST(JwksParseTest, GoodJwks) {
 
   EXPECT_EQ(jwks->keys()[0]->alg_, "RS256");
   EXPECT_EQ(jwks->keys()[0]->kid_, "62a93512c9ee4c7f8067b5a216dade2763d32a47");
-  EXPECT_TRUE(jwks->keys()[0]->alg_specified_);
-  EXPECT_TRUE(jwks->keys()[0]->kid_specified_);
 
   EXPECT_EQ(jwks->keys()[1]->alg_, "RS256");
   EXPECT_EQ(jwks->keys()[1]->kid_, "b3319a147514df7ee5e4bcdee51350cc890cc89e");
-  EXPECT_TRUE(jwks->keys()[1]->alg_specified_);
-  EXPECT_TRUE(jwks->keys()[1]->kid_specified_);
 }
 
 TEST(JwksParseTest, GoodEC) {
@@ -108,29 +104,21 @@ TEST(JwksParseTest, GoodEC) {
   EXPECT_EQ(jwks->keys()[0]->kid_, "abc");
   EXPECT_EQ(jwks->keys()[0]->kty_, "EC");
   EXPECT_EQ(jwks->keys()[0]->crv_, "P-256");
-  EXPECT_TRUE(jwks->keys()[0]->alg_specified_);
-  EXPECT_TRUE(jwks->keys()[0]->kid_specified_);
 
   EXPECT_EQ(jwks->keys()[1]->alg_, "ES256");
   EXPECT_EQ(jwks->keys()[1]->kid_, "xyz");
   EXPECT_EQ(jwks->keys()[1]->kty_, "EC");
   EXPECT_EQ(jwks->keys()[1]->crv_, "P-256");
-  EXPECT_TRUE(jwks->keys()[1]->alg_specified_);
-  EXPECT_TRUE(jwks->keys()[1]->kid_specified_);
 
   EXPECT_EQ(jwks->keys()[2]->alg_, "ES384");
   EXPECT_EQ(jwks->keys()[2]->kid_, "es384");
   EXPECT_EQ(jwks->keys()[2]->kty_, "EC");
   EXPECT_EQ(jwks->keys()[2]->crv_, "P-384");
-  EXPECT_TRUE(jwks->keys()[2]->alg_specified_);
-  EXPECT_TRUE(jwks->keys()[2]->kid_specified_);
 
   EXPECT_EQ(jwks->keys()[3]->alg_, "ES512");
   EXPECT_EQ(jwks->keys()[3]->kid_, "es512");
   EXPECT_EQ(jwks->keys()[3]->kty_, "EC");
   EXPECT_EQ(jwks->keys()[3]->crv_, "P-521");
-  EXPECT_TRUE(jwks->keys()[3]->alg_specified_);
-  EXPECT_TRUE(jwks->keys()[3]->kid_specified_);
 }
 
 TEST(JwksParseTest, EmptyJwks) {
@@ -577,15 +565,12 @@ TEST(JwksParseTest, JwksECUnspecifiedCrv) {
 
   EXPECT_EQ(jwks->keys()[0]->alg_, "ES256");
   EXPECT_EQ(jwks->keys()[0]->crv_, "P-256");
-  EXPECT_TRUE(jwks->keys()[0]->alg_specified_);
 
   EXPECT_EQ(jwks->keys()[1]->alg_, "ES384");
   EXPECT_EQ(jwks->keys()[1]->crv_, "P-384");
-  EXPECT_TRUE(jwks->keys()[1]->alg_specified_);
 
   EXPECT_EQ(jwks->keys()[2]->alg_, "ES512");
   EXPECT_EQ(jwks->keys()[2]->crv_, "P-521");
-  EXPECT_TRUE(jwks->keys()[2]->alg_specified_);
 }
 
 TEST(JwksParseTest, JwksGoodX509) {

--- a/src/verify.cc
+++ b/src/verify.cc
@@ -175,12 +175,12 @@ Status verifyJwt(const Jwt& jwt, const Jwks& jwks, uint64_t now) {
     // If kid is specified in JWT, JWK with the same kid is used for
     // verification.
     // If kid is not specified in JWT, try all JWK.
-    if (!jwt.kid_.empty() && jwk->kid_specified_ && jwk->kid_ != jwt.kid_) {
+    if (!jwt.kid_.empty() && !jwk->kid_.empty() && jwk->kid_ != jwt.kid_) {
       continue;
     }
 
     // The same alg must be used.
-    if (jwk->alg_specified_ && jwk->alg_ != jwt.alg_) {
+    if (!jwk->alg_.empty() && jwk->alg_ != jwt.alg_) {
       continue;
     }
     kid_alg_matched = true;

--- a/src/verify_pem_ec_test.cc
+++ b/src/verify_pem_ec_test.cc
@@ -109,7 +109,6 @@ TEST(VerifyPKCSTestRs256, OKPem) {
   auto jwks = Jwks::createFrom(es256pubkey, Jwks::Type::PEM);
   EXPECT_EQ(jwks->getStatus(), Status::Ok);
   jwks->keys()[0]->alg_ = "ES256";
-  jwks->keys()[0]->alg_specified_ = true;
   jwks->keys()[0]->crv_ = "P-256";
   EXPECT_EQ(verifyJwt(jwt, *jwks, 1), Status::Ok);
   fuzzJwtSignature(jwt, [&jwks](const Jwt& jwt) {
@@ -122,7 +121,6 @@ TEST(VerifyPKCSTestES384, OKPem) {
   EXPECT_EQ(jwt.parseFromString(JwtPemEs384), Status::Ok);
   auto jwks = Jwks::createFrom(es384pubkey, Jwks::Type::PEM);
   jwks->keys()[0]->alg_ = "ES384";
-  jwks->keys()[0]->alg_specified_ = true;
   jwks->keys()[0]->crv_ = "P-384";
   EXPECT_EQ(jwks->getStatus(), Status::Ok);
   EXPECT_EQ(verifyJwt(jwt, *jwks, 1), Status::Ok);
@@ -136,7 +134,6 @@ TEST(VerifyPKCSTestES512, OKPem) {
   EXPECT_EQ(jwt.parseFromString(JwtPemEs512), Status::Ok);
   auto jwks = Jwks::createFrom(es512pubkey, Jwks::Type::PEM);
   jwks->keys()[0]->alg_ = "ES512";
-  jwks->keys()[0]->alg_specified_ = true;
   jwks->keys()[0]->crv_ = "P-512";
   EXPECT_EQ(jwks->getStatus(), Status::Ok);
   EXPECT_EQ(verifyJwt(jwt, *jwks, 1), Status::Ok);
@@ -173,7 +170,6 @@ TEST(VerifyPKCSTestRs256, jwksIncorrectAlgSpecifiedFail) {
   EXPECT_EQ(jwks->getStatus(), Status::Ok);
   // Add incorrect Alg to jwks.
   jwks->keys()[0]->alg_ = "ES512";
-  jwks->keys()[0]->alg_specified_ = true;
   jwks->keys()[0]->crv_ = "P-512";
   EXPECT_EQ(verifyJwt(jwt, *jwks, 1), Status::JwksKidAlgMismatch);
   fuzzJwtSignature(jwt, [&jwks](const Jwt& jwt) {


### PR DESCRIPTION
This removes the alg_specified_ and kid_specified_ flags, and instead directly checks if the underlying string is empty.