### PR TITLE
Expand JWKs PEM API

### DIFF
--- a/jwt_verify_lib/jwks.h
+++ b/jwt_verify_lib/jwks.h
@@ -40,6 +40,15 @@ class Jwks : public WithStatus {
 
   // Create from string
   static std::unique_ptr<Jwks> createFrom(const std::string& pkey, Type type);
+  // Executes to createFrom with type=PEM and sets additional JWKS paramaters
+  // not specified within the PEM.
+  static std::unique_ptr<Jwks> createFromPem(const std::string& pkey,
+                                             const std::string& kid,
+                                             const std::string& alg);
+
+  // Adds a key to this keyset.
+  Status addKeyFromPem(const std::string& pkey, const std::string& kid,
+                       const std::string& alg);
 
   // Struct for JSON Web Key
   struct Pubkey {


### PR DESCRIPTION
This patch:
1. Adds the ability to set kid and alg when creating JWKs from PEM.
2. Adds the ability to add additional keys to an existing keyset. This
is necessary because previously it was only not possible to create a
keyset with more than one key from PEM.
3. Clean up a comment