### PR TITLE
Allow compilation with FIPS-mode boringssl

### DIFF
--- a/src/jwks.cc
+++ b/src/jwks.cc
@@ -479,6 +479,7 @@ void Jwks::createFromPemCore(const std::string& pkey_pem) {
       key_ptr->ec_key_.reset(EVP_PKEY_get1_EC_KEY(evp_pkey.get()));
       key_ptr->kty_ = "EC";
       break;
+#ifndef BORINGSSL_FIPS
     case EVP_PKEY_ED25519: {
       uint8_t raw_key[ED25519_PUBLIC_KEY_LEN];
       size_t out_len = ED25519_PUBLIC_KEY_LEN;
@@ -493,6 +494,7 @@ void Jwks::createFromPemCore(const std::string& pkey_pem) {
       key_ptr->crv_ = "Ed25519";
       break;
     }
+#endif
     default:
       updateStatus(Status::JwksPemNotImplementedKty);
       return;

--- a/src/verify_pem_okp_test.cc
+++ b/src/verify_pem_okp_test.cc
@@ -10,6 +10,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#ifndef BORINGSSL_FIPS
+
 #include "gtest/gtest.h"
 #include "jwt_verify_lib/verify.h"
 #include "src/test_common.h"
@@ -88,3 +90,5 @@ TEST(VerifyPEMTestOKP, WrongSignatureFail) {
 }  // namespace
 }  // namespace jwt_verify
 }  // namespace google
+
+#endif


### PR DESCRIPTION
Envoy supports being built in FIPS-mode so we need to be compatible with
that.