### PR TITLE
Add padded base64url payload string

### DIFF
--- a/jwt_verify_lib/jwt.h
+++ b/jwt_verify_lib/jwt.h
@@ -43,7 +43,9 @@ struct Jwt {
 
   // payload string
   std::string payload_str_;
-  // payload base64_url encoded(the raw one parsed from jwt_)
+  // payload base64_url encoded
+  // This is the original encoded payload parsed from `jwt_` and should be the one
+  // used in the jwt verification.
   std::string payload_str_base64url_;
   // payload base64_url encoded with padding
   std::string payload_str_base64url_padded_;

--- a/jwt_verify_lib/jwt.h
+++ b/jwt_verify_lib/jwt.h
@@ -43,8 +43,10 @@ struct Jwt {
 
   // payload string
   std::string payload_str_;
-  // payload base64_url encoded
+  // payload base64_url encoded(the raw one parsed from jwt_)
   std::string payload_str_base64url_;
+  // payload base64_url encoded with padding
+  std::string payload_str_base64url_padded_;
   // payload in Struct protobuf
   ::google::protobuf::Struct payload_pb_;
   // signature string

--- a/src/jwt.cc
+++ b/src/jwt.cc
@@ -93,6 +93,13 @@ Status Jwt::parseFromString(const std::string& jwt) {
     return Status::JwtPayloadParseErrorBadBase64;
   }
 
+  payload_str_base64url_padded_ = payload_str_base64url_;
+  if (payload_str_base64url_padded_.length() % 4 != 0) {
+    std::string trailing_padding(4 - payload_str_base64url_padded_.length() % 4,
+                                 '=');
+    payload_str_base64url_padded_.append(trailing_padding);
+  }
+
   const auto payload_status = ::google::protobuf::util::JsonStringToMessage(
       payload_str_, &payload_pb_, options);
   if (!payload_status.ok()) {


### PR DESCRIPTION
This PR provides the base64url payload string with padding.

**Risk**: low. Just like the added unit tests, the new one with padding should be equivalent to the original one after decoding. Of course, only the original one can be used in the JWT verification.

**Context**: although padding is not required by base64 encoding [spec](https://tools.ietf.org/html/rfc4648#section-3.2), some decode [libraries](https://stackoverflow.com/questions/3302946/how-to-decode-base64-url-in-python) are not robust enough to handle the one without padding.