### PR TITLE
Updated zlib to 1.2.12

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -129,8 +129,8 @@ def _rules_proto_repositories():
         urls = ["https://github.com/bazelbuild/rules_proto/archive/" + RULES_PROTO_COMMIT + ".tar.gz"],
     )
 
-ZLIB_RELEASE = "1.2.11"
-ZLIB_SHA256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1"
+ZLIB_RELEASE = "1.2.12"
+ZLIB_SHA256 = "91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9"
 
 def _zlib_repositories():
     http_archive(


### PR DESCRIPTION
The `zlib` 1.2.11 download is no longer available