### PR TITLE
Add GetPrimitiveFieldToString

### DIFF
--- a/jwt_verify_lib/struct_utils.h
+++ b/jwt_verify_lib/struct_utils.h
@@ -46,6 +46,11 @@ class StructUtils {
   FindResult GetStringList(const std::string& name,
                            std::vector<std::string>* list);
 
+  // This will fetch the field with primitive type, int, bool and string into a
+  // string
+  FindResult GetPrimitiveFieldToString(const std::string& name,
+                                       std::string* out_string);
+
  private:
   // Find the value field with nested names.
   FindResult FindNestedField(const std::string& nested_names,

--- a/jwt_verify_lib/struct_utils.h
+++ b/jwt_verify_lib/struct_utils.h
@@ -46,16 +46,11 @@ class StructUtils {
   FindResult GetStringList(const std::string& name,
                            std::vector<std::string>* list);
 
-  // This will fetch the field with primitive type, int, bool and string into a
-  // string
-  FindResult GetPrimitiveFieldToString(const std::string& name,
-                                       std::string* out_string);
+  // Find the value with nested names.
+  FindResult GetValue(const std::string& nested_names,
+                      const google::protobuf::Value*& found);
 
  private:
-  // Find the value field with nested names.
-  FindResult FindNestedField(const std::string& nested_names,
-                             const google::protobuf::Value*& found);
-
   const ::google::protobuf::Struct& struct_pb_;
 };
 

--- a/src/struct_utils.cc
+++ b/src/struct_utils.cc
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "jwt_verify_lib/struct_utils.h"
-#include "absl/strings/str_format.h"
 #include "absl/strings/str_split.h"
 
 namespace google {

--- a/src/struct_utils.cc
+++ b/src/struct_utils.cc
@@ -25,7 +25,7 @@ StructUtils::StructUtils(const ::google::protobuf::Struct& struct_pb)
 StructUtils::FindResult StructUtils::GetString(const std::string& name,
                                                std::string* str_value) {
   const ::google::protobuf::Value* found;
-  FindResult result = FindNestedField(name, found);
+  FindResult result = GetValue(name, found);
   if (result != OK) {
     return result;
   }
@@ -39,7 +39,7 @@ StructUtils::FindResult StructUtils::GetString(const std::string& name,
 StructUtils::FindResult StructUtils::GetDouble(const std::string& name,
                                                double* double_value) {
   const ::google::protobuf::Value* found;
-  FindResult result = FindNestedField(name, found);
+  FindResult result = GetValue(name, found);
   if (result != OK) {
     return result;
   }
@@ -69,7 +69,7 @@ StructUtils::FindResult StructUtils::GetUInt64(const std::string& name,
 StructUtils::FindResult StructUtils::GetBoolean(const std::string& name,
                                                 bool* bool_value) {
   const ::google::protobuf::Value* found;
-  FindResult result = FindNestedField(name, found);
+  FindResult result = GetValue(name, found);
   if (result != OK) {
     return result;
   }
@@ -83,7 +83,7 @@ StructUtils::FindResult StructUtils::GetBoolean(const std::string& name,
 StructUtils::FindResult StructUtils::GetStringList(
     const std::string& name, std::vector<std::string>* list) {
   const ::google::protobuf::Value* found;
-  FindResult result = FindNestedField(name, found);
+  FindResult result = GetValue(name, found);
   if (result != OK) {
     return result;
   }
@@ -103,38 +103,7 @@ StructUtils::FindResult StructUtils::GetStringList(
   return WRONG_TYPE;
 }
 
-StructUtils::FindResult StructUtils::GetPrimitiveFieldToString(
-    const std::string& name, std::string* out_string) {
-  const ::google::protobuf::Value* found;
-  FindResult result = FindNestedField(name, found);
-  if (result != OK) {
-    return result;
-  }
-  if (found->kind_case() == google::protobuf::Value::kNumberValue) {
-    if (found->number_value() < 0 ||
-        found->number_value() >=
-            static_cast<double>(std::numeric_limits<uint64_t>::max())) {
-      return OUT_OF_RANGE;
-    }
-    *out_string = std::to_string(static_cast<uint64_t>(found->number_value()));
-    return OK;
-  }
-  if (found->kind_case() == google::protobuf::Value::kStringValue) {
-    *out_string = found->string_value();
-    return OK;
-  }
-  if (found->kind_case() == google::protobuf::Value::kBoolValue) {
-    if (found->bool_value()) {
-      *out_string = "true";
-    } else {
-      *out_string = "false";
-    }
-    return OK;
-  }
-  return WRONG_TYPE;
-}
-
-StructUtils::FindResult StructUtils::FindNestedField(
+StructUtils::FindResult StructUtils::GetValue(
     const std::string& nested_names, const google::protobuf::Value*& found) {
   const std::vector<absl::string_view> name_vector =
       absl::StrSplit(nested_names, '.');

--- a/test/jwt_test.cc
+++ b/test/jwt_test.cc
@@ -569,24 +569,6 @@ TEST(JwtParseTest, GoodNestedJwt) {
   EXPECT_EQ(payload_getter.GetUInt64("nested.nested-2.key-4", &int_value),
             StructUtils::OK);
   EXPECT_EQ(int_value, 9999);
-
-  // fetching: nested.nested-2.key-2 = value2
-  EXPECT_EQ(payload_getter.GetPrimitiveFieldToString("nested.nested-2.key-2",
-                                                     &string_value),
-            StructUtils::OK);
-  EXPECT_EQ(string_value, "value2");
-
-  // fetching: nested.nested-2.key-3 = true as a string
-  EXPECT_EQ(payload_getter.GetPrimitiveFieldToString("nested.nested-2.key-3",
-                                                     &string_value),
-            StructUtils::OK);
-  EXPECT_EQ(string_value, "true");
-
-  // fetching: nested.nested-2.key-4 = 9999 as a string
-  EXPECT_EQ(payload_getter.GetPrimitiveFieldToString("nested.nested-2.key-4",
-                                                     &string_value),
-            StructUtils::OK);
-  EXPECT_EQ(string_value, "9999");
 }
 
 }  // namespace

--- a/test/jwt_test.cc
+++ b/test/jwt_test.cc
@@ -569,6 +569,24 @@ TEST(JwtParseTest, GoodNestedJwt) {
   EXPECT_EQ(payload_getter.GetUInt64("nested.nested-2.key-4", &int_value),
             StructUtils::OK);
   EXPECT_EQ(int_value, 9999);
+
+  // fetching: nested.nested-2.key-2 = value2
+  EXPECT_EQ(payload_getter.GetPrimitiveFieldToString("nested.nested-2.key-2",
+                                                     &string_value),
+            StructUtils::OK);
+  EXPECT_EQ(string_value, "value2");
+
+  // fetching: nested.nested-2.key-3 = true as a string
+  EXPECT_EQ(payload_getter.GetPrimitiveFieldToString("nested.nested-2.key-3",
+                                                     &string_value),
+            StructUtils::OK);
+  EXPECT_EQ(string_value, "true");
+
+  // fetching: nested.nested-2.key-4 = 9999 as a string
+  EXPECT_EQ(payload_getter.GetPrimitiveFieldToString("nested.nested-2.key-4",
+                                                     &string_value),
+            StructUtils::OK);
+  EXPECT_EQ(string_value, "9999");
 }
 
 }  // namespace


### PR DESCRIPTION
This method does not support double type, since we don't expect double in our use case, and it is not possible to know whether it's int or double without user input.