### PR TITLE
Update .bazelrc to use clang-10

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,6 +1,6 @@
 # Force the use of Clang for C++ builds.
-build --action_env=CC=clang-13
-build --action_env=CXX=clang++-13
+build --action_env=CC=clang-10
+build --action_env=CXX=clang++-10
 
 # Define the --config=asan-libfuzzer configuration.
 build:asan-libfuzzer --@rules_fuzzing//fuzzing:cc_engine=@rules_fuzzing//fuzzing/engines:libfuzzer


### PR DESCRIPTION
Our current CI image uses clang-10 instead of clang-13 ([failure message](https://oss.gprow.dev/view/gs/oss-prow/logs/jwt-verify-lib-periodic/1589951065686544384)).

Changing .bazelrc to use clang-10 for now, but we should probably update our CI image to use clang-13 (tracked in b/258203283)