### PR TITLE
Add CI docker image and update clang-format to 13

### DIFF
--- a/docker/Dockerfile-prow-env
+++ b/docker/Dockerfile-prow-env
@@ -1,0 +1,44 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM debian:bookworm
+
+LABEL maintainer="cloud-esf-dev@google.com"
+
+# add env we can debug with the image name:tag
+ARG IMAGE_ARG
+ENV IMAGE=${IMAGE_ARG}
+
+
+RUN apt-get update -y
+RUN apt-get -y install \
+    wget make cmake python3 python3-pip pkg-config coreutils \
+    zlib1g-dev curl libtool automake zip time rsync ninja-build \
+    git bash-completion jq default-jdk python3-distutils libicu-dev libbrotli-dev
+
+# # install Bazelisk
+RUN wget -O /usr/local/bin/bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.15.0/bazelisk-linux-amd64 && \
+    chmod +x /usr/local/bin/bazelisk && \
+    cp /usr/local/bin/bazelisk /usr/local/bin/bazel
+
+# install clang-13 and associated tools
+RUN wget -O- https://apt.llvm.org/llvm-snapshot.gpg.key| apt-key add - && \
+    echo "deb https://apt.llvm.org/buster/ llvm-toolchain-buster-13 main" >> /etc/apt/sources.list && \
+    apt-get update && \
+    apt-get install -y llvm-13 llvm-13-dev libclang-13-dev clang-13 \
+        lld-13 clang-tools-13 clang-format-13 libc++-dev xz-utils
+
+ENV CC clang-13
+ENV CXX clang++-13
+

--- a/docker/README
+++ b/docker/README
@@ -1,0 +1,24 @@
+## Docker images for jwt_verify_lib
+
+### How to build the image
+```sh
+docker build -f ${DOCKER_FILE_NAME} -t ${IMAGE_TAG} .
+```
+We can also inspect the image by running
+```sh
+docker run -it --entrypoint /bin/sh ${IMAGE_TAG}
+```
+
+### How to push the image
+Please refer to [Docker official
+documentation](https://docs.docker.com/engine/reference/commandline/push/#push-a-new-image-to-a-registry).
+
+#### Dockerfile-prow-env
+This image is used to run OSS Prow CI jobs.
+```sh
+# Build image
+docker build -f Dockerfile-prow-env  . -t gcr.io/cloudesf-testing/gcpproxy-prow:v${YYYYMMDD}-jwt-verify-lib
+# Push image to GCR
+docker image push gcr.io/cloudesf-testing/gcpproxy-prow:v${YYYYMMDD}-jwt-verify-lib
+```
+

--- a/docker/README
+++ b/docker/README
@@ -17,8 +17,8 @@ documentation](https://docs.docker.com/engine/reference/commandline/push/#push-a
 This image is used to run OSS Prow CI jobs.
 ```sh
 # Build image
-docker build -f Dockerfile-prow-env  . -t gcr.io/cloudesf-testing/gcpproxy-prow:v${YYYYMMDD}-jwt-verify-lib
+docker build -f Dockerfile-prow-env -t gcr.io/cloudesf-testing/jwt-verify-lib-prow:v{YYYYMMDD} .
 # Push image to GCR
-docker image push gcr.io/cloudesf-testing/gcpproxy-prow:v${YYYYMMDD}-jwt-verify-lib
+docker image push gcr.io/cloudesf-testing/jwt-verify-lib-prow:v{YYYYMMDD}
 ```
 

--- a/jwt_verify_lib/jwks.h
+++ b/jwt_verify_lib/jwks.h
@@ -18,7 +18,6 @@
 #include <vector>
 
 #include "jwt_verify_lib/status.h"
-
 #include "openssl/ec.h"
 #include "openssl/evp.h"
 #include "openssl/pem.h"

--- a/jwt_verify_lib/jwt.h
+++ b/jwt_verify_lib/jwt.h
@@ -18,7 +18,6 @@
 #include <vector>
 
 #include "google/protobuf/struct.pb.h"
-
 #include "jwt_verify_lib/status.h"
 
 namespace google {

--- a/script/check-style
+++ b/script/check-style
@@ -18,8 +18,9 @@
 #
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-CLANG_VERSION_REQUIRED="5.0.0"
-CLANG_FORMAT=$(which clang-format-${CLANG_VERSION_REQUIRED%.*})
+CLANG_VERSION_REQUIRED="13.0.0"
+CLANG_FORMAT=$(which clang-format-${CLANG_VERSION_REQUIRED%%.*})
+echo "which clang-format-${CLANG_VERSION_REQUIRED%.*}"
 if [[ ! -x "${CLANG_FORMAT}" ]]; then
   # Install required clang version to a folder and cache it.
   CLANG_DIRECTORY="${HOME}/clang"
@@ -28,19 +29,20 @@ if [[ ! -x "${CLANG_FORMAT}" ]]; then
   if [ "$(uname)" == "Darwin" ]; then
     CLANG_BIN="x86_64-apple-darwin.tar.xz"
   elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
-    CLANG_BIN="linux-x86_64-ubuntu14.04.tar.xz"
+    CLANG_BIN="x86_64-linux-gnu-ubuntu-16.04.tar.xz"
   else
     echo "Unsupported environment." ; exit 1 ;
   fi
 
-  echo "clang-bin: https://releases.llvm.org/${CLANG_VERSION_REQUIRED}/clang+llvm-${CLANG_VERSION_REQUIRED}-${CLANG_BIN}"
+  echo "clang-bin: https://github.com/llvm/llvm-project/releases/download/llvmorg-${CLANG_VERSION_REQUIRED}/clang+llvm-${CLANG_VERSION_REQUIRED}-${CLANG_BIN}"
 
   CLANG_VERSION="$(${CLANG_FORMAT} -version | cut -d ' ' -f 3)"
+  echo "CLANG_VERSION: ${CLANG_VERSION}"
   if [[ "${CLANG_VERSION}" != "${CLANG_VERSION_REQUIRED}" ]]; then
     echo "Installing required clang-format ${CLANG_VERSION_REQUIRED} to ${CLANG_DIRECTORY}"
     mkdir -p ${CLANG_DIRECTORY}
-    curl --silent --show-error --retry 10 \
-      "https://releases.llvm.org/${CLANG_VERSION_REQUIRED}/clang+llvm-${CLANG_VERSION_REQUIRED}-${CLANG_BIN}" \
+    curl --show-error --retry 10 \
+      -L "https://github.com/llvm/llvm-project/releases/download/llvmorg-${CLANG_VERSION_REQUIRED}/clang+llvm-${CLANG_VERSION_REQUIRED}-${CLANG_BIN}" \
       | tar Jx -C "${CLANG_DIRECTORY}" --strip=1 \
     || { echo "Could not install required clang-format. Skip formating." ; exit 0 ; }
   fi

--- a/script/check-style
+++ b/script/check-style
@@ -20,7 +20,6 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 CLANG_VERSION_REQUIRED="13.0.0"
 CLANG_FORMAT=$(which clang-format-${CLANG_VERSION_REQUIRED%%.*})
-echo "which clang-format-${CLANG_VERSION_REQUIRED%.*}"
 if [[ ! -x "${CLANG_FORMAT}" ]]; then
   # Install required clang version to a folder and cache it.
   CLANG_DIRECTORY="${HOME}/clang"
@@ -37,7 +36,6 @@ if [[ ! -x "${CLANG_FORMAT}" ]]; then
   echo "clang-bin: https://github.com/llvm/llvm-project/releases/download/llvmorg-${CLANG_VERSION_REQUIRED}/clang+llvm-${CLANG_VERSION_REQUIRED}-${CLANG_BIN}"
 
   CLANG_VERSION="$(${CLANG_FORMAT} -version | cut -d ' ' -f 3)"
-  echo "CLANG_VERSION: ${CLANG_VERSION}"
   if [[ "${CLANG_VERSION}" != "${CLANG_VERSION_REQUIRED}" ]]; then
     echo "Installing required clang-format ${CLANG_VERSION_REQUIRED} to ${CLANG_DIRECTORY}"
     mkdir -p ${CLANG_DIRECTORY}

--- a/simple_lru_cache/simple_lru_cache_inl.h
+++ b/simple_lru_cache/simple_lru_cache_inl.h
@@ -899,22 +899,22 @@ void SimpleLRUCacheBase<Key, Value, MapType, EQ>::discardIdle(
   int64_t last = 0;
 #endif
   while ((e != &head_) && (e->last_use_ < threshold)) {
-  // Sanity check: LRU list should be sorted by last_use_. We could
-  // check the entire list, but that gives quadratic behavior.
-  //
-  // TSCs on different cores of multi-core machines sometime get slightly out
-  // of sync; compensate for this by allowing clock to go backwards by up to
-  // kAcceptableClockSynchronizationDriftCycles CPU cycles.
-  //
-  // A kernel bug (http://b/issue?id=777807) sometimes causes TSCs to become
-  // widely unsynchronized, in which case this CHECK will fail. As a
-  // temporary work-around, running
-  //
-  //  $ sudo bash
-  //  # echo performance>/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
-  //  # /etc/init.d/cpufrequtils restart
-  //
-  // fixes the problem.
+    // Sanity check: LRU list should be sorted by last_use_. We could
+    // check the entire list, but that gives quadratic behavior.
+    //
+    // TSCs on different cores of multi-core machines sometime get slightly out
+    // of sync; compensate for this by allowing clock to go backwards by up to
+    // kAcceptableClockSynchronizationDriftCycles CPU cycles.
+    //
+    // A kernel bug (http://b/issue?id=777807) sometimes causes TSCs to become
+    // widely unsynchronized, in which case this CHECK will fail. As a
+    // temporary work-around, running
+    //
+    //  $ sudo bash
+    //  # echo performance>/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
+    //  # /etc/init.d/cpufrequtils restart
+    //
+    // fixes the problem.
 #ifndef NDEBUG
     assert(last <= e->last_use_ + kAcceptableClockSynchronizationDriftCycles);
     last = e->last_use_;

--- a/src/check_audience.cc
+++ b/src/check_audience.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "jwt_verify_lib/check_audience.h"
+
 #include "absl/strings/match.h"
 
 namespace google {

--- a/src/struct_utils.cc
+++ b/src/struct_utils.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "jwt_verify_lib/struct_utils.h"
+
 #include "absl/strings/str_split.h"
 
 namespace google {

--- a/test/check_audience_test.cc
+++ b/test/check_audience_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "jwt_verify_lib/check_audience.h"
+
 #include "gtest/gtest.h"
 
 namespace google {

--- a/test/fuzz/corpus_format_test.cc
+++ b/test/fuzz/corpus_format_test.cc
@@ -1,14 +1,11 @@
-#include "jwt_verify_lib/jwks.h"
-#include "jwt_verify_lib/jwt.h"
-#include "jwt_verify_lib/verify.h"
-
 #include <fstream>
 
 #include "absl/strings/str_cat.h"
 #include "google/protobuf/text_format.h"
-
 #include "gtest/gtest.h"
-
+#include "jwt_verify_lib/jwks.h"
+#include "jwt_verify_lib/jwt.h"
+#include "jwt_verify_lib/verify.h"
 #include "test/fuzz/jwt_verify_lib_fuzz_input.pb.h"
 
 namespace google {

--- a/test/fuzz/jwt_verify_lib_fuzz_test.cc
+++ b/test/fuzz/jwt_verify_lib_fuzz_test.cc
@@ -12,14 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.#pragma once
 
-#include "jwt_verify_lib/jwks.h"
-#include "jwt_verify_lib/jwt.h"
-#include "jwt_verify_lib/verify.h"
-
 #include <cstddef>
 #include <cstdint>
 #include <string>
 
+#include "jwt_verify_lib/jwks.h"
+#include "jwt_verify_lib/jwt.h"
+#include "jwt_verify_lib/verify.h"
 #include "src/libfuzzer/libfuzzer_macro.h"
 #include "test/fuzz/jwt_verify_lib_fuzz_input.pb.h"
 

--- a/test/simple_lru_cache_test.cc
+++ b/test/simple_lru_cache_test.cc
@@ -17,10 +17,10 @@ limitations under the License.
 // Tests fo SimpleLRUCache
 
 #include "simple_lru_cache/simple_lru_cache.h"
-#include "simple_lru_cache/simple_lru_cache_inl.h"
 
 #include <math.h>
 #include <unistd.h>
+
 #include <algorithm>
 #include <cmath>
 #include <iostream>
@@ -30,6 +30,7 @@ limitations under the License.
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "simple_lru_cache/simple_lru_cache_inl.h"
 
 using ::testing::HasSubstr;
 using ::testing::NotNull;


### PR DESCRIPTION
- clang-format-13 updates the formats for some existing code
- image is pushed to gcr.io/cloudesf-testing/jwt-verify-lib-prow:v20221109

Note:
CI will fail unless the image is updated in https://github.com/GoogleCloudPlatform/oss-test-infra/pull/1831

Because In this change we updated `clang-format` from `5.0.0` to `13.0.0`, the only issue with the [espv2 image](https://github.com/GoogleCloudPlatform/esp-v2/blob/master/docker/Dockerfile-prow-env) now is just `bazel`. `bazelisk` was installed there, but we didn't link `bazelisk` to `bazel`.
We can add `cp /usr/local/bin/bazelisk /usr/local/bin/bazel` to alias `bazelisk` to `bazel`, then we're good.

Having a separate image for this repo has the following benefits
- Less image size since we don't install node.js, go and gcloud.
- This repo is more self-contained.