### PR TITLE
Return empty string in src/status.cc

### DIFF
--- a/src/status.cc
+++ b/src/status.cc
@@ -179,6 +179,8 @@ std::string getStatusString(Status status) {
     case Status::JwksBioAllocError:
       return "Failed to create BIO due to memory allocation failure";
   };
+  // Return empty string though switch-case is exhaustive. See issues/91.
+  return "";
 }
 
 }  // namespace jwt_verify


### PR DESCRIPTION
Fix https://github.com/google/jwt_verify_lib/issues/91

/cc @qiwzhang 