### PR TITLE
fix zlib urls

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -128,7 +128,7 @@ def _zlib_repositories():
         build_file = "@com_google_protobuf//:third_party/zlib.BUILD",
         sha256 = ZLIB_SHA256,
         strip_prefix = "zlib-" + ZLIB_RELEASE,
-        urls = ["https://zlib.net/zlib-" + ZLIB_RELEASE + ".tar.gz"],
+        urls = ["https://github.com/madler/zlib/releases/download/v" + ZLIB_RELEASE +"/zlib-"+ ZLIB_RELEASE + ".tar.gz"],
     )
 
 PROTOBUF_RELEASE = "3.16.0"  # Mar 04, 2021


### PR DESCRIPTION
```console
wget https://zlib.net/zlib-1.2.13.tar.gz
--2023-10-25 18:10:01--  https://zlib.net/zlib-1.2.13.tar.gz
Resolving zlib.net (zlib.net)... 85.187.148.2
Connecting to zlib.net (zlib.net)|85.187.148.2|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2023-10-25 18:10:03 ERROR 404: Not Found.
```